### PR TITLE
Add missing reference to Figure 1

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,7 @@
 import os
 import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+numfig = True
 # -- General configuration ------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/flamegpu/introduction.rst
+++ b/flamegpu/introduction.rst
@@ -54,7 +54,7 @@ the lifecycle of a single iteration. This allows a mechanism for agents
 to iteratively interact in a way which allows emergent global group
 behaviour.
 
-The process of generating a FLAME GPU simulation is described by the 1.
+The process of generating a FLAME GPU simulation is described by :numref:`figure1-label`.
 The use of XML schemas forms a large part of the process where
 polymorphic like extension allows a base schema specification to be
 extended with a number of GPU specific elements. Given an XMML model
@@ -69,6 +69,7 @@ which links with the *Agent Function Files* to generate a simulation
 program.
 
 .. figure:: /images/figure1.jpg
+   :name: figure1-label
    :alt: FLAME GPU Modelling and Simulation Processes
    :width: 100.0%
 


### PR DESCRIPTION
I think, the link to Figure 1 was expected to be auto-generated by the interpreter, however, it is not happening. The proposed solution depends on adding a setting to the configuration file and a name to the figure.  
Here is a screenshot of what the change produces
![image](https://user-images.githubusercontent.com/1790200/66960625-c2605600-f064-11e9-80ee-3e78626334a5.png)
