### PR TITLE
Add missing links from introduction

### DIFF
--- a/flamegpu/introduction.rst
+++ b/flamegpu/introduction.rst
@@ -79,9 +79,9 @@ Purpose of This Document
 
 The purpose of this document is to describe the functional parts which
 make up a FLAME GPU simulation as well as providing guidance on how to
-use the FLAME GPU SDK. describes in detail the syntax and format of the
-XMML Model file. describes the syntax of use of agent function scripts
-and how to use the dynamic simulation API and describes how to generate
+use the FLAME GPU SDK. :ref:`modelspec` describes in detail the syntax and format of the
+XMML Model file. :ref:`api` describes the syntax of use of agent function scripts
+and how to use the dynamic simulation API, and :ref:`simulation` describes how to generate
 simulation code and run simulations from within the Visual Studio IDE.
 This document does not act as a review of background material relating
 to GPU agent modelling, nor does it provide details on FLAME GPUs


### PR DESCRIPTION
The links to the various sections were missing. I think they should look as follows.

![image](https://user-images.githubusercontent.com/1790200/66961265-28011200-f066-11e9-9de2-6312bb147cf7.png)
