### PR TITLE
Spelling, wording and grammar fixes

### DIFF
--- a/flamegpu/api.rst
+++ b/flamegpu/api.rst
@@ -10,15 +10,15 @@ Introduction
 
 Agent function scripts define the behaviour of agents by describing changes to memory and through the iteration and creation of messages and new agents.
 The behaviour of the agent function is described from the perspective of a single agent however the simulator will apply in parallel the same agent function code to each agent which is in the correct start state (and meets any of the defined function conditions).
-Agent function scripts are defined using a simple C based syntax with the agent function declarations, and more specifically the function arguments dependant on the XMML function definition.
+Agent function scripts are defined using a simple C based syntax with the agent function declarations, and more specifically the function arguments, dependent on the XMML function definition.
 The use of message input and output as well as random number generation will all change the function arguments in a way which is described within this section.
-Likewise the simulation API functions for message communication are dependent on the definition of the simulation model contained with the XMML model definition.
+Likewise, the simulation API functions for message communication are dependent on the definition of the simulation model contained with the XMML model definition.
 A single C source file is required to hold all agent function declarations and must contain an include directive for the file ``header.h`` which contains model specific agent and message structures.
 Agent functions are free to use many features of common C syntax with the following important exceptions: 
 
 - Globally Defined Variables: i.e. Variables declared outside of any function scope are not permitted and should instead be defined as global variables within the XMML model file and used as described in :ref:`Simulation Constants (Global Variables)`. *Note: The use of pre-processor macro directives for constants is supported and can be freely used without restriction.*
-- Include Directives: Are permitted however as agent functions are functions which are ran on the GPU during simulation they may not call non GPU code. This implies that including and linking with non CUDA libraries is not supported.
-- External Function Calls: As above external function calls may only be made to CUDA ``__device__`` functions. Many common math functions calls such as ``sin``, ``cos``, etc. are supported via native GPU implementations and can be used in exactly the same way as standard C code. Likewise additional *helper* functions can be defined and called from agent functions by prefixing the helper function using the ``__FLAME_GPU_FUNC__`` macro (which signifies it can be run on the GPU device).
+- Include Directives: Are permitted, however, as agent functions are functions which are run on the GPU during simulation, they may not call non GPU code. This implies that including and linking with non CUDA libraries is not supported.
+- External Function Calls: As above external function calls may only be made to CUDA ``__device__`` functions. Many common math functions calls such as ``sin``, ``cos``, etc. are supported via native GPU implementations and can be used in exactly the same way as standard C code. Likewise, additional *helper* functions can be defined and called from agent functions by prefixing the helper function using the ``__FLAME_GPU_FUNC__`` macro (which signifies it can be run on the GPU device).
 
 The following chapter describes the syntax and use of agent function scripts including any arguments which must be passed to the agent or simulation API functions.
 As agent functions and simulation API functions are dynamic (and based on the XMML model definition) it is often easier to first define a model and use the technique described within :ref:`Generating a Functions File Template` to automatically generate a functions file containing prototype agent function files and API system calls.
@@ -29,7 +29,7 @@ Agent and Message Data Structures
 =================================
 
 Access to agent and message data within the agent function scripts is provided through the use of agent and message data structures which contain variables matching those defined within the XMML definitions.
-For each agent in the simulation a structure is defined within the dynamically generated ``header.h`` with the name ``xmachine_memory_agent_*name*``, likewise each message defines a structure with the name ``xmachine_message_message_*name*`` where ``*name**`` represents the agent or message ``name`` from the model description respectively.
+For each agent in the simulation a structure is defined within the dynamically generated ``header.h`` with the name ``xmachine_memory_agent_*name*``, likewise, each message defines a structure with the name ``xmachine_message_message_*name*`` where ``*name**`` represents the agent or message ``name`` from the model description respectively.
 In both cases the structures contain a number of private variables prefixed with an underscore (e.g. ``_``) which are used internally by the API functions and should not be modified by the user.
 In addition to this the simulation API defines structures of arrays to hold agent and message list information.
 Agent lists are named ``xmachine_memory_agent_*name*_list`` and message lists are named \``xmachine_message_message_*name*_list``.
@@ -40,7 +40,7 @@ A Basic Agent Function
 ======================
 
 
-The following example shows a simplistic agent function ``function1`` which has no message input or output and only updates the agents internal memory.
+The following example shows a simplistic agent function ``function1`` which has no message input or output and only updates the agent's internal memory.
 All FLAME GPU agent functions are first prefixed with the macro definition ``__FLAME_GPU_FUNC__``.
 In this basic example the agent function has only a single argument, a pointer to an agent structure of type ``xmachine_memory_myAgent`` called ``xmemory``.
 In the below example the agent ``name`` is ``myAgent`` and the agent memory contains two variables ``x`` and ``no_movements`` of type ``float`` and ``int`` respectively.
@@ -75,7 +75,7 @@ Agent functions may only call a message output function for the message name def
 This restriction is enforced as message output functions require a pointer to a message list which is passed as an argument to the agent function.
 Agents are only permitted to output at most a single message per agent function and repeated calls to an add message function will result in previous message information simply being overwritten.
 The example below demonstrates an agent function ``output_message`` belonging to an agent named ``myAgent`` which outputs a message with the name ``location`` defined as having four variables.
-For clarity the message output function prototype (normally found in ``header.h``) is also shown.
+For clarity, the message output function prototype (normally found in ``header.h``) is also shown.
 
 .. code-block:: c
    :linenos:
@@ -111,9 +111,9 @@ In general two functions are provided for each named message, a ``get_first_*nam
 The arguments of these functions differ slightly depending on the partitioning scheme used by the message.
 The following subsections describe these in more detail.
 Regardless of the partitioning type a number of important rules must be observed when using the message functions.
-Firstly it is essential that message loop complete naturally.
+Firstly, it is essential that message loop completes naturally.
 I.e. the ``get_next_*name*_message`` function must be called without breaking from the while loop until the end of the message list is reached.
-Secondly agent functions must not directly modify messages returned from the get message functions.
+Secondly, agent functions must not directly modify messages returned from the get message functions.
 Changing message data directly will result in undefined behaviour and will most likely crash the simulation 
 
 
@@ -177,7 +177,7 @@ Spatially Partitioned Message Iteration
 
 For spatially partitioned messages the dynamically generated message API functions rely on the use of a Partition Boundary Matrix (PBM).
 The PBM holds important information which determines which agents are located within the spatially partitioned areas making up the simulation environment.
-Wherever a spatially partitioned message is defined as a function input (within the XMML model definition) a PMB argument should directly follow the input message list in the list of agent function arguments.
+Wherever a spatially partitioned message is defined as a function input (within the XMML model definition) a PBM argument should directly follow the input message list in the list of agent function arguments.
 As with non partitioned messages the first argument of the get first message API function is the input message list.
 The second argument is the PBM and the subsequent three arguments represent the position which the agent would like to read messages from (which in almost all cases is the agent position).
 The get next message API function differs only from the non partitioned example in that the PBM is passed as an additional parameter.
@@ -185,7 +185,7 @@ The example below shows the same example as in the previous section but using a 
 The differences between the function arguments in the previous section are highlighted in red as is the use of a helper function ``in_range``.
 The purpose of the ``in_range`` function is to check the distance between the agent position and the message.
 This is important as the messages returned by the get next message function represent any messages within the same or adjacent partitioning cells (to the position specified by the get first message API function).
-On average roughly :math:`1/3` of these values will be within the actually range specified by the message definitions range value.
+On average roughly :math:`1/3` of these values will be within the actual range specified by the message definitions range value.
 
 
 .. code-block:: c
@@ -244,7 +244,7 @@ The two integer arguments represent the position which the agent would like to r
 These values of these arguments must therefore be within the width and height of the message space itself (the square of the messages ``bufferSize``).
 In addition to the additional arguments, the discrete message API functions also make use of template parameterisation to distinguish between the type of agent requesting message information.
 The template parameters which may be used are either ``DISCRETE_2D`` (as in the example below) or ``CONTINUOUS``.
-This parameterisation is required as underlying implementation of the message API functions differs between the two agent types.
+This parameterisation is required as the underlying implementation of the message API functions differs between the two agent types.
 The example below shows an agent function (``input_messages``) of a discrete agent (named ``cell``) which iterates a message list (of state messages) to count the number neighbours with a state value of ``1``.
 
 .. The differences between the function arguments in the section describing non partitioned message iteration are highlighted in red as is the function parameterisation.
@@ -272,7 +272,7 @@ The example below shows an agent function (``input_messages``) of a discrete age
 Graph Edge Partitioned Message Iteration
 ----------------------------------------
 
-For graph edge partitioned messages the dynamically generated message API functions rely on the use of a message boundary structure. The structure holds important information which determines which messages belong to each edge of the graph data structure. 
+For graph edge partitioned messages, the dynamically generated message API functions rely on the use of a message boundary structure. The structure holds important information which determines which messages belong to each edge of the graph data structure. 
  As with other message types the first argument is the input message list. 
  The second argument is the message boundary structure, and the third argument is the id of the edge for which messages should be loaded (usually the edge where the agent is located).
  The ``get_next`` message API function differs only from the non partitioned example in that the message boundary structure is passed as an additional parameter.
@@ -321,7 +321,7 @@ I.e.
     #define xmachine_message_MESSAGE_partitioningSpatial
     #define xmachine_message_MESSAGE_partitioningGraphEdge
 
-These macros can then be used to write a single ``functions.c`` file which can be used with different partitioning shchemes in the ``XMLModelFile.XML``.
+These macros can then be used to write a single ``functions.c`` file which can be used with different partitioning schemes in the ``XMLModelFile.XML``.
 
 .. code-block:: c
    :linenos:
@@ -351,7 +351,7 @@ These macros can then be used to write a single ``functions.c`` file which can b
 Use of the Agent Output Simulation API
 ======================================
 
-Within an agent function script, agent output is possible on the host from Init and Step functions, and on the device by using a agent output API function.
+Within an agent function script, agent output is possible on the host from Init and Step functions, and on the device by using an agent output API function.
 
 Agent Creation from the Host
 ----------------------------
@@ -360,12 +360,12 @@ Within ``__FLAME_GPU_INIT_FUNC`` and ``__FLAME_GPU_STEP_FUNC`` (or within custom
 
 Several steps must be followed to make use of this feature.
 
-1. Allocate enough host (CPU) memory for all as many agents as you would like to create within the host function.
+1. Allocate enough host (CPU) memory for as many agents as you would like to create within the host function.
 2. Populate the agent data on the host.
 3. Copy agent data from the host to the device.
 4. Deallocate host memory when it is no longer required.
 
-If agents are only create in an ``INIT`` function, then the above procedure can be local to that ``INIT`` function.
+If agents are only created in an ``INIT`` function, then the above procedure can be local to that ``INIT`` function.
 
 If agents are going to be created in ``STEP`` functions, it is more efficient to split this procedure over an ``INIT`` function, a ``STEP`` function and an ``EXIT`` function.
 In this case, in ``functions.c`` you should declare a host memory in the global scope. An ``INIT`` function is then used to allocate sufficient memory, agents are created in the ``STEP`` function and lastly the ``EXIT`` function is used to deallocate and free resources.
@@ -422,7 +422,7 @@ Where ``*name*`` refers to the value of the agents ``name`` element within the a
 Agent functions may only output a single type of agent and are only permitted to output a single agent per agent function.
 As with message outputs, repeated calls to an add agent function will result in previous agent information simply being overwritten.
 The example below demonstrates an agent function (``create_agent``) for an agent named ``myAgent`` which outputs a new agent by creating a clone of itself.
-For clarity the agent output API function prototype (normally found in ``header.h``) is also shown.
+For clarity, the agent output API function prototype (normally found in ``header.h``) is also shown.
 
 .. code-block:: c
    :linenos:
@@ -468,8 +468,8 @@ Using Random Number Generation
 ==============================
 
 Random number generation is provided via the ``rnd`` API function which uses template parameterisation to distinguish between either discrete (where a template parameter value of ``DISCRETE_2D`` should be used) or continuous (where a template parameter value of ``CONTINUOUS`` should be used) spaced agents.
-If a template parameter value is not specified then the simulation will assume a ``DISCRETE_2D`` value which will work in either case but is more computationally expensive.
-The API function has a single argument, a pointer to a ``RNG_rand48`` structure which contains random seeds and is passed to agent functions which specify a true value for the RNG element in the XMML function definition.
+If a template parameter value is not specified, then the simulation will assume a ``DISCRETE_2D`` value which will work in either case but is more computationally expensive.
+The API function has a single argument, a pointer to an ``RNG_rand48`` structure which contains random seeds and is passed to agent functions which specify a true value for the RNG element in the XMML function definition.
 The API function returns a pseudorandom `float` uniformly distributed within the range `[0.0,1.0)`.
 The example below shows a simple agent function (with no input or outputs) demonstrating the random number generation to determine if the agent should die.
 
@@ -570,7 +570,7 @@ Note that Exit functions are not executed by the default visualisation.
 Runtime Host Functions
 ======================
              
-Runtime host functions can be used to interact with the model outside of the main simulation loop. For example runtime host functions can be used to set simulation constants, gather analytics for plotting or sorting agents for rendering. Typically these functions are used within step, init or exit functions however they can also be used within custom visualisations. In addition to the functionality in this section it is also possible to create agents on the host which are injected into the simulation (see :ref:`Agent Creation from the Host`).
+Runtime host functions can be used to interact with the model outside of the main simulation loop. For example, runtime host functions can be used to set simulation constants, gather analytics for plotting or sorting agents for rendering. Typically, these functions are used within step, init or exit functions however they can also be used within custom visualisations. In addition to the functionality in this section it is also possible to create agents on the host which are injected into the simulation (see :ref:`Agent Creation from the Host`).
              
 Getting and Setting Simulation Constants (Global Variables)
 -----------------------------------------------------------
@@ -633,7 +633,7 @@ In addition, for each member variable defined for each vertex, and each edge a f
 Sorting Agents
 --------------
 
-Each `CONTINUOUS` type agent can be sorted based on key value pairs which come from agent variables. This can be particularly useful for rendering. A function for sorting each agent (named `*agent*`) state list (in the below example the state is named `default`) is created with the folowing format.
+Each `CONTINUOUS` type agent can be sorted based on key value pairs which come from agent variables. This can be particularly useful for rendering. A function for sorting each agent (named `*agent*`) state list (in the below example the state is named `default`) is created with the following format.
 
 .. code-block:: c
 
@@ -686,7 +686,7 @@ The value `xmachine_memory_agent_MAX` is the buffer size of number of agents (se
 Analytics Functions
 -------------------
 
-A dynamically generated *reduce* function is made for all agent variables for each state. A dynamically generated *count*, *min* and *max* functions will only be created for single-value (not array) variables. Count functions are limited to `int` type variables (including short, long and vector type variants), min and max functions are limited to non vector type variables (e.g. no dvec2 type of variables). Reduce functions sum over a particular variable variable for all agents in the state list and returns the total. Count functions check how many values are equal to the given input and returns the quantity that match. These *analytics* functions are typically used with  init, step and exit functions to calculate averages or distributions of a given variable. E.g. for agent agent with a *name* of `agentName`, *state* of `default` and an `int` variable name `varName` the following analytics functions will be created.
+A dynamically generated *reduce* function is made for all agent variables for each state. A dynamically generated *count*, *min* and *max* functions will only be created for single-value (not array) variables. Count functions are limited to `int` type variables (including short, long and vector type variants), min and max functions are limited to non vector type variables (e.g. no dvec2 type of variables). Reduce functions sum over a particular variable for all agents in the state list and returns the total. Count functions check how many values are equal to the given input and returns the quantity that match. These *analytics* functions are typically used with  init, step and exit functions to calculate averages or distributions of a given variable. E.g. for an agent with a *name* of `agentName`, *state* of `default` and an `int` variable name `varName` the following analytics functions will be created.
 
 .. code-block:: c
    :linenos:
@@ -709,7 +709,7 @@ For non-array agent variables, a single argument ``index`` refers to the positio
 For array agent variables, two arguments are required, ``index`` and ``element``, where ``index`` is the agent position within the state list, and ``element`` is the 0 indexed element of the agent array. 
 I.e. ``get_AGENT_STATE_variable_ARRAY(0, 2)`` would return the 2nd element of the agent variable ``ARRAY`` for the 0th ``AGENT`` agent in the state ``STATE``.
 
-This enables the creation of custom agent output functions as step functions, if you do not require all agent data in output XML files. For instance, it can be used to create a CSV file. See the ``customOutputStepFunc`` step function for the ``HostAgentCreation`` example.
+This enables the creation of custom agent output functions as step functions if you do not require all agent data in output XML files. For instance, it can be used to create a CSV file. See the ``customOutputStepFunc`` step function for the ``HostAgentCreation`` example.
 
 
 Exiting the Simulation Early

--- a/flamegpu/introduction.rst
+++ b/flamegpu/introduction.rst
@@ -30,8 +30,8 @@ Technically, the FLAME GPU framework is not a simulator, it is instead a
 template-based simulation environment that maps formal descriptions of
 agents into simulation code. The representation of an agent is based on
 the concept of a communicating X-Machine (which is an extension to the
-Finite State Machine which includes memory). Whilst the X-Machine has
-very formal definition X-Machine agents can be thought of as state
+Finite State Machine which includes memory). Whilst the X-Machine has a
+very formal definition, X-Machine agents can be thought of as state
 machines able to communicate via messages stored in
 globally accessible message lists. Agent functionality is exposed as a
 set of state transition functions which move agents from one internal
@@ -42,13 +42,13 @@ be passed to the message lists for other agents to read). FLAME GPU uses
 agent function scripting for this purpose where the script is defined in a
 number of *Agent Function Files*. Simulation models are specified using
 a format called X-Machine Mark-up Language (*XMML*) which is XML syntax
-with Schemas governing the content. A typically XMML model file consists
+with Schemas governing the content. A typical XMML model file consists
 of a definition of a number of X-Machine agents (including state and
 memory information as well as a set of agent transition functions), a
 number of message types (each of which has a globally accessible message
 list) and a set of simulation layers which define the execution order of
-agent functions (which constitutes a single simulation iteration).
-Throughout a simulation, agent data is persistent however message
+agent functions (which constitute a single simulation iteration).
+Throughout a simulation, agent data is persistent, however, message
 information (and in particular message lists) is persistent only over
 the lifecycle of a single iteration. This allows a mechanism for agents
 to iteratively interact in a way which allows the emergent global group

--- a/flamegpu/modelspec.rst
+++ b/flamegpu/modelspec.rst
@@ -9,7 +9,7 @@ Introduction
 ============
 
 FLAME GPU models are specified using XML format within an XMML document.
-The syntax of the model file is governed by two XML Schemas, an abstract base Schema describes the syntax of a basic XMML agent model (compatible with HPC and CPU versions of the FLAME framework) and a concrete GPU Schema extension this to add various bits of additional model information.
+The syntax of the model file is governed by two XML Schemas, an abstract base Schema describes the syntax of a basic XMML agent model (compatible with HPC and CPU versions of the FLAME framework) and a concrete GPU Schema which extends this to add various bits of additional model information.
 Within this chapter the XML namespace (xmlns) gpu is used to qualify the XML elements which extend the basic Schema representation.
 A high level overview of a an XMML model file is described below with various sections within this chapter describing each part in more detail.
 
@@ -55,7 +55,7 @@ Simulation constants are defined as (global) variables and may be of type int, f
 Constant variables must each have a unique name which is used to reference them within simulation code and can have an optional static array length (of size greater than 0). Table [var_types]  summarizes the supported data types for the environment variables.
 The description element arrayLength element and defaultValue element are all optional.
 The below code shows the specification of two constant variables: the first represents a single ``int`` constant (with a default value of ``1``), the second indicates an ``int`` array of length ``5``.
-Simulation constants can be set either as default values as show below, within the initial agent XML file (see :ref:`Initial Simulation Constants`) or at run-time are described in :ref:`Host Simulation Hooks`. Values set in initial XML values will overwrite a default value and values which are set at runtime will overwrite values set in initial agent XML files.
+Simulation constants can be set either as default values as shown below, within the initial agent XML file (see :ref:`Initial Simulation Constants`) or at run-time as described in :ref:`Host Simulation Hooks`. Values set in initial XML values will overwrite a default value and values which are set at runtime will overwrite values set in initial agent XML files.
 
 .. code-block:: xml
    :linenos:
@@ -113,7 +113,7 @@ If an ``initFunctions`` element is specified there must be at least a single ``i
 Step Functions
 --------------
 
-Step functions are similarly defined to initialisation functions, requiring at least a single ``stepFunction`` child element if the ``stepFunctions`` element is defined. These functions are called at the end of each iteration step, i.e. after all the layers, as defined in section :ref:`Step Functions (API)`, are executed each step. Example uses of this function are to calculate agent averages during the iteration step or sort functions.
+Step functions are defined similarly to initialisation functions, requiring at least a single ``stepFunction`` child element if the ``stepFunctions`` element is defined. These functions are called at the end of each iteration step, i.e. after all the layers, as defined in section :ref:`Step Functions (API)`, are executed each step. Example uses of this function are to calculate agent averages during the iteration step or sort functions.
 
 .. code-block:: xml
    :linenos:
@@ -146,10 +146,10 @@ Graph Data Structures
 
 Some agent based models may contain environmental data structures as a graph. To ensure high performance access of this data, and enable communication restricted to a graph based data structure FLAME GPU 1.5.0 introduces a list of graphs to the environment.
 
-Graphs are implemented using the Compressed Spares Row (CSR) data, enable high performance read access. Currently it is not possible to pragmatically modify (or update) the graph data structure at runtime.
+Graphs are implemented using the Compressed Sparse Row (CSR) data format, enabling high performance read access. Currently it is not possible to pragmatically modify (or update) the graph data structure at runtime.
 
 The following example shows the definition of a static graph with the name ``graph``, with a text description.
-The ``<gpu:loadFromFile>`` tag defines that the graph is to be loaded from a ``json`` file stored on disk, called ``network.json``. This path is relative to the initial states file. Alternatively the graph can be loaded from an XML format via ``<gpu:xml>relative/path/to/file.xml</gpu:xml>``.
+The ``<gpu:loadFromFile>`` tag defines that the graph is to be loaded from a ``json`` file stored on disk, called ``network.json``. This path is relative to the initial states file. Alternatively, the graph can be loaded from an XML format via ``<gpu:xml>relative/path/to/file.xml</gpu:xml>``.
 
 The ``<gpu:vertex>`` and ``<gpu:edge>`` tags define the list of ``<variables>`` which the data structure contains, and the maximum number of each type of element via the ``<gpu:bufferSize>`` tag. 
 Vertices require a variable called `id`, with an integer based type, such as ``int``, ``unsigned int``, ``unsigned long long int`` etc. 
@@ -212,16 +212,16 @@ Edges require an ``id`` variable of an integer type, a ``source`` variable of an
 Defining an X-Machine Agent
 ===========================
 
-A XMML model file must contain a single ``xagents`` element which in turn must define at least a single ``xagent``.
+An XMML model file must contain a single ``xagents`` element which in turn must define at least a single ``xagent``.
 An ``xagent`` is an agent representation of an X-Machine and consists of a name, optional description, an internal memory set (*M* in the formal definition), a set of agent functions (or next state partial functions, *F*, in the formal definition) and a set of states (*Q* in the formal definition).
-In addition to this FLAMEGPU requires two additional pieces of information (which are not required in the original XMML specification), a ``type`` and a ``bufferSize``.
+In addition to this, FLAMEGPU requires two additional pieces of information (which are not required in the original XMML specification), a ``type`` and a ``bufferSize``.
 The ``type`` element refers to the type of agent with respect to its relation with its spatial environment.
-An agent type can be either ``discrete`` or ``continuous``, discrete agents occupy non mobile 2D discrete spatial partitions (cellular automaton) where as continuous agents are assumed to occupy a continuous space environment (although in reality they may in fact be non spatial more abstract agents).
+An agent type can be either ``discrete`` or ``continuous``, discrete agents occupy non mobile 2D discrete spatial partitions (cellular automaton) whereas continuous agents are assumed to occupy a continuous space environment (although in reality they may in fact be non spatial more abstract agents).
 As all memory is pre-allocated on the GPU a ``bufferSize`` is required to represent the largest possible size of the agent population.
 That is the maximum number of x-machine agent instances of the format described by the XMML model.
 There is no performance disadvantage to using a large ``bufferSize`` however it is the user's responsibility to ensure that the GPU contains enough memory to support large populations of agents.
 It is recommended that the bufferSize always be a power of two number (i.e. ``1024``, ``2048``, ``4096``, ``16384``, etc) as it will most likely be rounded to one during simulation.
-For discrete agents the bufferSize is strictly limited to only power of 2 numbers which have squarely divisible dimensions (i.e. the square of the bufferSize must be a whole number).
+For discrete agents, the bufferSize is strictly limited to only power of 2 numbers which have squarely divisible dimensions (i.e. the square of the bufferSize must be a whole number).
 If at any point in the simulation exceeds the stated ``bufferSize`` then the user will be warned at the simulation will exit. Care must be taken when defining the value of bufferSize. Any datatype which would exceed the stack limit of 2GB (calculated as bufferSize*sizeof(agent variable data type) will fail to build under windows. E.g. This limits the bufferSize for 4byte variables (int, float, etc) to 62.5 million.
 
 Each expandable aspect of an XMML agent representation in the below example is discussed within this section with the exception of agent functions, which due to their dependence of the definition of messages, are discussed later in :ref:`Defining an Agent function`.
@@ -250,7 +250,7 @@ Agent Memory
 ------------
 
 
-Agent memory consists of a number of variables (at least one) which are use to hold information.
+Agent memory consists of a number of variables (at least one) which are used to hold information.
 An agent ``variable`` must have a unique ``name`` and may be of ``type`` ``int``, ``float`` or ``double`` (CUDA compute capability 1.3 or beyond). Table [var_types]  summarizes the supported data types for the agent variables.
 Default values are always ``0`` unless a ``defaultValue`` element is specified or if a value is specified within the XML input states file (which supersedes the default value).
 There are no specified limits on the maximum number of agent variables however the performance tips noted in :ref:`Performance Tips` should be taken into account.
@@ -331,9 +331,9 @@ Message partition schemes are used to ensure that the most optimal cycling of me
 Message Variables
 -----------------
 
-The message ``variables`` element consists of a number of ``variable`` elements (at least one) which are use to hold communication information.
+The message ``variables`` element consists of a number of ``variable`` elements (at least one) which are used to hold communication information.
 A ``variable`` must have a unique ``name`` and may be of ``type`` ``{int``, ``float`` or ``double`` (CUDA Compute capability 2.0 or beyond). 
-Unlike with agent variables, message variables support only scalar single memory values (i.e. no static or dynamic arrays). Table [var_types]  summarizes the supported data types for the message variables.
+Unlike agent variables, message variables support only scalar single memory values (i.e. no static or dynamic arrays). Table [var_types]  summarizes the supported data types for the message variables.
 There are no specified limits on the maximum number of message variables however increased message size will have a negative effect on performance in all partitioning cases (and in particular when non partitioned messages are used).
 The format of message variable specification shown below is identical to that of agent memory.
 The only exception is the requirement of certain variable names which are required by certain partitioning types.
@@ -361,11 +361,11 @@ The example below shows an example of message memory containing two message vari
 Non partitioned Messages
 ------------------------
 
-None partitioned messages do not use any filtering mechanism to reduce the number of messages which will be iterated by agent functions which use the message as input.
-None partitioned messages therefore require a brute force or :math:`O(n^{2})` message iteration loop wherever the message list is iterated.
+Non partitioned messages do not use any filtering mechanism to reduce the number of messages which will be iterated by agent functions which use the message as input.
+Non partitioned messages therefore require a brute force or :math:`O(n^{2})` message iteration loop wherever the message list is iterated.
 As non partitioned messages do not require any message variables with location information the partition type is particularly suitable for communication between non spatial or more abstract agents.
 Brute force iteration is obviously computationally expensive, however non partitioned message iteration requires very little overhead (or setup) cost and as a result for small numbers of messages it can be more efficient than either limited range technique.
-There is no strict rule governing performance and different GPU hardware will produce different results depending on it capability.
+There is no strict rule governing performance and different GPU hardware will produce different results depending on its capability.
 It is therefore left to the user to experiment with different message partitioning types within a simulation.
 The example below shows the format of the partitioningNone element tag.
 
@@ -379,7 +379,7 @@ Discrete Partitioned Messages
 -----------------------------
 
 Discrete partitioned messages are messages which may only originate from non mobile discrete agents (cellular automaton).
-A discrete partitioning message scheme requires the specification of a radius which indicates the range (in in 2D discrete space) which a message iteration will extend to.
+A discrete partitioning message scheme requires the specification of a radius which indicates the range (in 2D discrete space) which a message iteration will extend to.
 A radius value of ``0`` indicates that only a single message will be returned from message iteration.
 A value of greater than ``0`` indicates that message iteration will loop through radius directions in both the ``x`` and a ``y`` dimension, but ignore the centre cell (e.g.
 a range of ``1`` will iterate ``(3x3)-1=8`` messages, a range of ``2`` will iterate ``(5x5)-1=24``).
@@ -405,14 +405,14 @@ Spatially partitioned messages are messages which originate from continuous spac
 A spatially partitioned message scheme requires the specification of both a radius and a set of environment bounds.
 The ``radius`` represents the range in which message iteration will extend to (from its originating point).
 The environment bounds represent the size of the space which massages may exist within.
-If a message falls outside of the environment bounds then it will be bound to the nearest possible location within it.
+If a message falls outside of the environment bounds, then it will be bound to the nearest possible location within it.
 The space within the defined bounds is partitioned according to the radius with a total of ``P`` partitions in each dimension, where for each dimension;
 
 .. math::
     P = ceiling((max\_bound - min\_bound) / radius)
 
-The partitions dimensions are then used to construct a partition boundary matrix (an example of use within message iteration is provided in :ref:`Spatially Partitioned Message Iteration`) which holds the indices of messages within each area of partitioned space. The value of ``P`` must not exceed 62.5 million due to limitations on the size of stack memory.
-The value of ``P`` must be at least 3 in both the ``x`` and ``y`` axis, and at least ``1`` in the ``z`` axis, else a compilation error will occur. If the desired configuration does not meet these critera consider using Non Partitioned Messages.
+The partition's dimensions are then used to construct a partition boundary matrix (an example of use within message iteration is provided in :ref:`Spatially Partitioned Message Iteration`) which holds the indices of messages within each area of partitioned space. The value of ``P`` must not exceed 62.5 million due to limitations on the size of stack memory.
+The value of ``P`` must be at least 3 in both the ``x`` and ``y`` axis, and at least ``1`` in the ``z`` axis, else a compilation error will occur. If the desired configuration does not meet these criteria, consider using Non Partitioned Messages.
 Spatially partitioned message iteration can then iterate a varying number of messages from a fixed number of adjacent partitions in partition space to ensure each message within the specified radius has been considered.
 When iterating messages, the environment is wrapped in the ``x`` and ``y`` axis to form a torus. No wrapping occurs in the ``z`` axis. 
 
@@ -439,9 +439,9 @@ For continuously spaced agents in 2D space ``P`` in the x z dimension should be 
 Graph Edge Partitioned Messaging
 --------------------------------
 
-Graph Edge Partitioned messages are messages which originate from continuous spaces agents in an environment where communication is restricted to the structure of a graph. I.e agents which traverse along a network such as a road network. A graph edge partitioned message scheme requires the specification of a graph and the corresponding message variable which refers to the graph edge id.
+Graph Edge Partitioned messages are messages which originate from continuous spaces agents in an environment where communication is restricted to the structure of a graph. I.e. agents which traverse along a network such as a road network. A graph edge partitioned message scheme requires the specification of a graph and the corresponding message variable which refers to the graph edge id.
 
-Messages are sorted by the ``messageEdgeId`` variable, which enables high performance access to messages on the edge. Using the graph data structure it is then possible to traverse the graph accessing messages from multiple edges.
+Messages are sorted by the ``messageEdgeId`` variable, which enables high performance access to messages on the edge. Using the graph data structure, it is then possible to traverse the graph accessing messages from multiple edges.
 
 The following example defines a graph edge partitioning scheme corresponding to a ``staticGraph`` named ``graph`` where the message variable ``edge_id`` contains the edge from which the message corresponds.
 
@@ -485,7 +485,7 @@ Defining an Agent function
 An optional list of agent ``functions`` is described within an X-Machine agent representation and must contain a list of at least a single agent ``function`` element.
 In turn, a function must contain a non optional ``name``, an optional ``description``, a ``currentState``, ``nextState``, an optional single message input, and optional single message output, an optional single agent output, an optional global function condition, an optional function condition, a reallocation flag and a random number generator flag.
 The current state is defined within the ``currentState`` element and is used to filter the agent function by only applying it to agents in the specified state.
-After completing the agent function agents then move into the state specified within the ``nextState`` element.
+After completing the agent function, agents then move into the state specified within the ``nextState`` element.
 Both the current and ``nextState`` values are required to have values which exist as a state/name within the state list (states) definition.
 The ``reallocate`` element is used as an optional flag to indicate the possibility that an agent performing the agent function may die as a result (and hence require removing from the agent population).
 By default this value is assumed ``true`` however if a value of false is specified then the processes for removing dead agents will not be executed even if an agent indicates it has died (see agent function definitions in :ref:`Defining an Agent function`).
@@ -519,7 +519,7 @@ Agent Function Message Inputs
 
 An agent function message input indicates that the agent function will iterate the list of messages with a name equal to that specified by the non optional messageName element.
 It is therefore required that the ``messageName`` element refers to an existing (XPath) ``messages/message/name`` defined within the XMML document.
-In addition to this an agent function cannot iterate a list of messages without specifying that it is an ``input`` within the XMML model file (message iteration functions are parameterised to prevent this).
+In addition to this, an agent function cannot iterate a list of messages without specifying that it is an ``input`` within the XMML model file (message iteration functions are parameterised to prevent this).
 
 .. code-block:: xml
    :linenos:
@@ -542,7 +542,7 @@ The type may be either``single_message`` or ``optional_message``, where ``single
 The type of messages which can be output by discrete agents are not restricted however continuous type agents can only output messages which do not use discrete message partitioning (e.g.
 no partitioning or spatial partitioning).
 The example below shows a message output using ``single_message`` type.
-This will assume every agent outputs a message, if the functions script fails to output a message for every agent a message with default values (of ``0``) will be created instead.
+This will assume every agent outputs a message. If the functions script fails to output a message for every agent, a message with default values (of ``0``) will be created instead.
 
 .. code-block:: xml
    :linenos:
@@ -561,7 +561,7 @@ Agent Function X-Agent Outputs
 An agent function ``xagentOutput`` indicates that the agent function will output an agent with a name equal to that specified by the non optional ``xagentName`` element.
 This differs slightly from the formal definition of an x-machine which does not explicitly define a technique for the creation of new agents but adds functionality required for dynamically changing population sizes during simulation runtime.
 The ``xagentName`` element belonging to an ``xagentOutput`` element must refer to an existing (XPath) ``xagents/agent/name`` defined within the XMML document.
-It is not possible for an agent function script to output a agent without specifying that it is an ``xagentOutput`` within the XMML model file (agent output functions are parameterised to prevent this).
+It is not possible for an agent function script to output an agent without specifying that it is an ``xagentOutput`` within the XMML model file (agent output functions are parameterised to prevent this).
 In addition to the ``xagentName`` element a message output also requires a ``state``.
 The ``state`` represents the state from the list of state elements belonging to the specified agent which the new agent should be created in.
 Only ``continuous`` type agents are allowed to output new agents (which must also be of type ``continuous``).
@@ -585,8 +585,8 @@ Function Conditions
 
 An agent function ``condition`` indicates that the agent function should only be applied to agents which meet the defined condition (and in the correct state specified by ``currentState``).
 Each function condition consists of three parts a left hand side statement (``lhs``), an ``operator`` and a right hand side statement (``rhs``).
-Both the ``lhs`` and ``rhs`` elements may contain either a ``agentVariable`` a value or a recursive condition element.
-An ``agentVariable`` element must refer to a agent variable defined within the agents list of variable names (i.e. the XPath equivalent of 
+Both the ``lhs`` and ``rhs`` elements may contain either an ``agentVariable`` a value or a recursive condition element.
+An ``agentVariable`` element must refer to an agent variable defined within the agents list of variable names (i.e. the XPath equivalent of 
 ``xagent/memory/variable/name``).
 A ``value`` element may refer to any numeric value or constant definition (defined within the agent function scripts).
 The use of recursive conditions is demonstrated below by embedding a condition within the ``rhs`` element of the top level condition.
@@ -625,7 +625,7 @@ In the above example the function condition generates the following pseudo code 
 The ``condition`` element may refer to any logical operator.
 Care must be taken when using angled brackets which in standard form will cause the XML syntax to become invalid.
 Rather than the left hand bracket (less than) the correct xml syntax of 
-``&lt;`` should be used. Likewise the right hand bracket (greater than) should be replaced with 
+``&lt;`` should be used. Likewise, the right hand bracket (greater than) should be replaced with 
 ``&gt;``.
 
 .. note ::
@@ -650,7 +650,7 @@ For example, the definition at the end of this section, resulting in the followi
     (((movement) < (0.25)) == true)
 
 May be evaluated as false up to ``200`` times (i.e. in ``200`` separate simulation iterations) before the global condition will be ignored and the function is applied to every agent.
-Following maximum number of iterations being reached the iteration count is reset once the agent function has been applied.
+Following the maximum number of iterations being reached, the iteration count is reset once the agent function has been applied.
 
 .. code-block:: xml
    :linenos:
@@ -672,15 +672,15 @@ Following maximum number of iterations being reached the iteration count is rese
 Function Layers
 ===============
 
-Function layers represent the control flow of the simulation processes and hence describes any functional dependencies.
+Function layers represent the control flow of the simulation processes and hence describe any functional dependencies.
 The sequence of layers defines the sequential order in which agent functions are executed.
 Complete execution of every layer of agent functions represents a single simulation iteration which may be repeated any number of times.
-Synthetically within the model definition a single layers element must contain at least one (or more) layer element.
+Syntactically, the model definition a single layers element must contain at least one (or more) layer element.
 Each layer element may contain at least one (or more) ``gpu:layerFunction`` elements which defines only a ``name`` which must correspond to a function name (e.g. the XPath equivalent of ``xagents/xagent/functions/function/name``.
 Within a given layer, the order of execution of layer functions should not be assumed to be sequential (although in the current version of the software it is, future versions will execute functions within the same layer in parallel).
 For the same reason functions within the same layer should not have any communication or internal dependencies (for example via message communications or execution order dependency) in which case they should instead be represented within separate layers which guarantee execution order and global synchronisation between the functions. Functions which apply to the same agent must therefore also not exist within the same layer.
 The below example demonstrates the syntax of specifying a simulation consisting of three agent functions.
-There are no dependencies between ``function1`` and ``function2`` which in this case can be thought of as being functions from two different agents definitions with no shared message inputs or outputs.
+There are no dependencies between ``function1`` and ``function2`` which in this case can be thought of as being functions from two different agents' definitions with no shared message inputs or outputs.
 
 .. code-block:: xml
    :linenos:
@@ -709,11 +709,11 @@ Initial XML Agent Data
 The initial agent data information is stored in an XML file which is passed to the simulator as a parameter before running the simulation.
 Within this initial agent data XML file, a single ``states`` element contains a single iteration number ``itno`` and any number of (including none) ``xagent`` elements.
 The syntax of the ``xagent`` element depends on the agent definitions contained within the XMML model definition file.
-A ``name`` element is always required and must represent an agent name contained within the XPath equivalent of ``xgents/agent/name`` in the XMML model definition.
-Following this an element may exist for each of the named agents memory variables (XPath) ``xagents/agent/memory/variable/name``).
+A ``name`` element is always required and must represent an agent name contained within the XPath equivalent of ``xagents/agent/name`` in the XMML model definition.
+Following this an element may exist for each of the named agent's memory variables (XPath) ``xagents/agent/memory/variable/name``).
 Each named element is then expected to contain a value of the same ``type`` as the agent memory variable defined.
-If the initial agent data XML file neglects to specify the value of a variable defined within an agents memory then the value is assumed to be the ``defaultValue`` otherise ``0``.
-If an element defines a variable name which does not exist within the XMML model definition then a warning is generated and the value is ignored.
+If the initial agent data XML file neglects to specify the value of a variable defined within an agent's memory, then the value is assumed to be the ``defaultValue`` otherwise ``0``.
+If an element defines a variable name which does not exist within the XMML model definition, then a warning is generated and the value is ignored.
 The example below represents a single agent corresponding to the agent definition in :ref:`Defining an X-Machine Agent`.
 
 .. code-block:: xml
@@ -733,10 +733,10 @@ The example below represents a single agent corresponding to the agent definitio
 
 
 Care must be taken in ensuring that the set of initial data for the simulation does not exceed any of the defined ``bufferSize`` (i.e. the maximum number of a given type of agents) for any of the agents.
-If buffer size is exceeded during initial loading of the initial agent data then the simulation will produce an error.
+If buffer size is exceeded during initial loading of the initial agent data, then the simulation will produce an error.
 
 Another special case to consider is the use of 2D discrete agents where the number of agents within the set of initial agent data must match exactly the ``bufferSize`` (which must also be a power of 2) defined within the XMML models agent definition.
-Furthermore the simulation will expect to find initial agents stored within the XML file in row wise ascending order.
+Furthermore, the simulation will expect to find initial agents stored within the XML file in row wise ascending order.
 
 Initial Simulation Constants
 ----------------------------
@@ -854,11 +854,11 @@ FLAME GPU supports the commonly used scalar types and a set of vector types (cur
 +==========================+=======================================================================+
 | bool                     | Conditional type with values of true or false                         |
 +--------------------------+-----------------------------------------------------------------------+
-| (unsgined) char          | Integer type using (typically)  8 bits. Can be signed or unsigned     |
+| (unsigned) char          | Integer type using (typically)  8 bits. Can be signed or unsigned     |
 +--------------------------+-----------------------------------------------------------------------+
-| (unsgined) short         | Integer type using (typically) 16 bits. Can be signed or unsigned     |
+| (unsigned) short         | Integer type using (typically) 16 bits. Can be signed or unsigned     |
 +--------------------------+-----------------------------------------------------------------------+
-| (unsgined) int           | Integer type using (typically) 32 bits. Can be signed or unsigned     |
+| (unsigned) int           | Integer type using (typically) 32 bits. Can be signed or unsigned     |
 +--------------------------+-----------------------------------------------------------------------+
 | (unsigned) long long int | Integer type using (typically) 64 bits. Can be signed or unsigned     |
 +--------------------------+-----------------------------------------------------------------------+
@@ -896,7 +896,7 @@ FLAME GPU supports the commonly used scalar types and a set of vector types (cur
 | dvec4       | double       | 4        |
 +-------------+--------------+----------+
 
-In addition FLAME GPU supports array variables, for agent member variables, environment constants and as member variables of staticGraphs. Array variables are **not** supported for message variables.
+In addition, FLAME GPU supports array variables, for agent member variables, environment constants and as member variables of staticGraphs. Array variables are **not** supported for message variables.
 
 +-----------------------+-----------------------+-----------------+
 |                       | Scalar & Vector Types | Array Variables |

--- a/flamegpu/simulation.rst
+++ b/flamegpu/simulation.rst
@@ -8,17 +8,17 @@
 Introduction
 ============
 
-The processes of building and running a simulation is made easier described within this chapter as are a number of tools and procedures which simplify the simulation code generation and compilation of simulation executables.
+The processes for building and running a simulation are described within this chapter, as are a number of tools and procedures which simplify the simulation code generation and compilation of simulation executables.
 In order to use the FLAME GPU SDK it should be placed in a directory which does not contain any spaces (preferably directly within the C: drive or root or root operating system drive).
 The host machine must also be running windows with a copy of the .NET runtime (used within the XSLT template processor) and must contain NVIDIA GPU hardware with Compute level 1.0.
 
 Generating a Functions File Template
 ====================================
 
-Chapter :ref:`Summary of Agent Function Arguments` previously described the exact argument order for agent function declarations however in most cases it is sensible to use the provided XSLT template ``functions.xslt`` located in the ``FLAMEGPU/templates`` directory within the FLAME GPU SDK) to generate a agent function source file with empty agent function declarations automatically using your XMML model file.
+Chapter :ref:`Summary of Agent Function Arguments` previously described the exact argument order for agent function declarations however in most cases it is sensible to use the provided XSLT template ``functions.xslt`` located in the ``FLAMEGPU/templates`` directory within the FLAME GPU SDK) to generate an agent function source file with empty agent function declarations automatically using your XMML model file.
 Once this has been generated the agent function scripts can be implemented within the function declarations rather easily.
 Care must however be taken in ensuring that if the XMML model file is later modified that the agent function arguments are updated manually where necessary.
-Likewise be careful not to overwrite any existing function source file when generating a new one using the XSLT template.
+Likewise, be careful not to overwrite any existing function source file when generating a new one using the XSLT template.
 Generation of blank function source files is not incorporated into the visual studio template project and must be manually accomplished.
 A .NET based XSLT processor is provided within the FLAME GPU SDK for this purpose (``XSLTProcessor.exe`` located in the ``tools`` directory) and can be used via the command line as follows (or via the ``GenerateFunctionsFileTemplate`` batch file located in the ``tools`` directory of the FLAME GPU SDK);
 
@@ -27,7 +27,7 @@ A .NET based XSLT processor is provided within the FLAME GPU SDK for this purpos
     XSLTProcessor.exe XMLModelFile.xml functions.xslt functions.c
 
 
-Alternatively any compliant XSLT processor such as Xalan, Unicorn or even Firefox web browser can be used.
+Alternatively, any compliant XSLT processor such as Xalan, Unicorn or even Firefox web browser can be used.
 
 FLAME GPU Template Files
 ========================
@@ -55,21 +55,21 @@ Visual Studio Project Build Configurations
 ------------------------------------------
 
 The FLAME GPU examples and template project file contain build configurations 64 bit Windows (``x64``) environments. 32 bit windows has been removed due to limitations on GPU memory addressing since version 1.3.0.
-For each platform the project also contains four configurations for debugging (``Debug``) and release versions (``Release``) of both ``console`` based simulation and ``visualisation`` simulation.
+For each platform, the project also contains four configurations for debugging (``Debug``) and release versions (``Release``) of both ``console`` based simulation and ``visualisation`` simulation.
 The two debug options disable all compiler optimisations and generate debug information for debugging host (non GPU) code and enables CUDA device emulation for GPU (device) debugging.
 The visualisation configurations enable building of visualisation code and specify a pre processor macro (``VISUALISATION``) which is used by a number of pre-processor conditionals to change the simulations expected arguments (see :ref:`Simulation Execution Modes and Options`).
 
 Visual Studio Project Virtual File Structure
 --------------------------------------------
 
-Within the FLAME GPU examples and template projects code is organised into the following virtual folders; 
+Within the FLAME GPU examples and template projects, code is organised into the following virtual folders; 
 
-- ``FLAME GPU`` Consisting of a folder containing the FLAME GPU XML schemas and Code generating templates. These files are shared amongst all examples so editing them will change simulation code generated for other projects.
+- ``FLAME GPU`` Consisting of a folder containing the FLAME GPU XML schemas and code generating templates. These files are shared amongst all examples so editing them will change simulation code generated for other projects.
 - ``FLAMEModel`` Contains the XMML model file and the agent functions file (usually called ``functions.c``). Note that the ``functions.c`` file is actually excluded from the build processes as it is built by the dynamically generated ``simulation.cu`` source file which includes it.
 - ``Dynamic Code`` Contains the dynamically generated FLAME GPU simulation code. This code will be overwritten each time the project is built so any changes to this files will be lost unless template transformation is turned off using the FLAME GPU build rule (see :ref:`FLAME GPU Build Rule Options`).
-- *Additional Source Code* This folder should contain any hard coded simulation specific source or header files. By default the FLAME GPU project template defines a single ``visualisation.h`` file in this folder which may be modified to set a number of variables such as viewing distance and clipping. Within the FLAME GPU examples this folder is typically used to sore any model specific visualisation code which replaces the dynamically generated visualisation source file.
+- *Additional Source Code* This folder should contain any hard coded simulation specific source or header files. By default, the FLAME GPU project template defines a single ``visualisation.h`` file in this folder which may be modified to set a number of variables such as viewing distance and clipping. Within the FLAME GPU examples this folder is typically used to store any model specific visualisation code which replaces the dynamically generated visualisation source file.
 
-The physical folders of the SDK structure a self explanatory however it is worth noting that executable files generated by the Visual Studio build processes are output in the SDKs ``bin`` folder which also contains the CUDA run time ``dlls``. 
+The physical folders of the SDK structure are self explanatory however it is worth noting that executable files generated by the Visual Studio build processes are output in the SDKs ``bin`` folder which also contains the CUDA run time ``dlls``. 
 
 Build Process
 -------------
@@ -78,8 +78,8 @@ The Visual Studio build process consists of a number of stages which call variou
 The first of these is the FLAME GPU build tool (described in more detail in the following section) which generates the dynamic simulation code from the FLAME GPU templates and mode file.
 Following this the simulation code (within the Dynamic Code folder) is built using the CUDA build rule which compiles the source files using the NVIDIA CUDA compiler 
 ``nvcc``.
-Finally any C or C++ source files are compiled using MSVC compiler and are then linked with the CUDA object files to produce the executable.
-To start the build processes select the ``Build`` menu followed by ``Build Solution`` or use the ``F7`` hotkey.
+Finally, any C or C++ source files are compiled using MSVC compiler and are then linked with the CUDA object files to produce the executable.
+To start the build processes, select the ``Build`` menu followed by ``Build Solution`` or use the ``F7`` hotkey.
 If the first build step in the Visual Studio skips the FLAME GPU build tool a complete rebuilt can be forced by selecting the ``Build`` menu followed by ``Rebuild Solution`` (or ``Ctrl + Alt + F7``).
 
 FLAME GPU Build Rule Options
@@ -102,7 +102,7 @@ Visual Studio Launch Configuration Command Arguments
 In order to set the execution arguments (described in the next section) for simulation executable in any one of one of the four launch configurations, the ``Command Arguments`` property can be set form the Project Properties Page (Select ``Project`` Menu followed by ``FLAMEGPU\_Project Properties``).
 The ``Command Arguments`` property is located under ``Configuration Properties -> Debug`` (see :ref:`Agent Function Scripts and the Simulation API`).
 Each configuration has its own set of ``Command Arguments`` so when moving between configurations these will need to be set.
-Likewise the ``Configuration Properties`` are computer and user specific so these cannot be preset and must be specified the first time each example is compiled and run.
+Likewise, the ``Configuration Properties`` are computer and user specific so these cannot be preset and must be specified the first time each example is compiled and run.
 The Visual Studio macro ``$InputDir`` can be used to specify the working directory of the project file which makes locating initial agent data XML files for many of the examples much easier (these are normally located in the iterations folders of each example).
 
 The Command Arguments have been set the simulation executable can be launched by selecting ``Start Debugging`` from the ``Debug`` menu or using the ``F5`` hotkey (this is the same in both release and debug launch configurations).
@@ -137,8 +137,8 @@ Or for a visualisation example in release mode:
 In the project specific portion of the Makefile (i.e ``examples/EmptyExample/Makefile``) several variables exist which allow the project to be customised.
 
 - ``EXAMPLE``: Controls the name of the project / executables generated.
-- ``HAS_VISUALISATION``: Determins if a visualisation mode should be supported or not.
-- ``CUSTOM_VISUALISATION``: Determins if a custom or the default visualisation should be used.
+- ``HAS_VISUALISATION``: Determines if a visualisation mode should be supported or not.
+- ``CUSTOM_VISUALISATION``: Determines if a custom or the default visualisation should be used.
 - ``FLAMEGPU_ROOT``: The relative path from the Makefile to the main ``FLAMEGPU`` directory. I.e. ``../../``
 - ``EXAMPLE_BIN_DIR``: Path to the location to place executables.
 - ``EXAMPLE_BUILD_DIR``: Path to the build directory for this project.
@@ -159,7 +159,7 @@ Creating a New FLAME GPU Example Project
 
 The simplest way to create a new FLAME GPU example project is to copy and modify an existing project, renaming visual studio solution / project files, and modifying the Makefile.
 
-A python script is provided to simplify this process for you, makeing the required changes. I.e. to create a new example projected called ``NewExample``, based on the ``EmptyExample`` run the following command.
+A python script is provided to simplify this process for you, making the required changes. I.e. to create a new example projected called ``NewExample``, based on the ``EmptyExample`` run the following command.
 
 .. code-block:: bash
 
@@ -220,11 +220,11 @@ Many of the options for the default visualisation are contained within the ``vis
 
 - ``SIMULATION_DELAY`` Many simulations are executed extremely quickly making visualisation a blur. This definition allows an artificial delay by executing this number of visualisation render loops before each simulation iteration is processed.
 - ``WINDOW_WIDTH`` and ``WINDOW_HEIGHT`` Specifies the size of the visualisation window 
-- ``NEAR_CLIP`` and ``FAR_CLIP`` Specifies the near an far clipping plane used for OpenGL rendering.
+- ``NEAR_CLIP`` and ``FAR_CLIP`` Specifies the near and far clipping planes used for OpenGL rendering.
 - ``SPHERE_SLICES`` The number of slices used to create the sphere geometry representing a single agent in the visualisation.
 - ``SPHERE_STACKS`` The number of stacks used to create the sphere geometry representing a single agent in the visualisation.
 - ``SPHERE_RADIUS`` The physical size of the sphere geometry representing a single agent in the visualisation. This will need to be a sensible value which corresponds with the environment size and agent locations within your model/simulation.
-- ``VIEW_DISTANCE`` The camera viewing distance. Again this will need to be a sensible value which corresponds with the environment size and agent locations within your model/simulation.
+- ``VIEW_DISTANCE`` The camera viewing distance. Again, this will need to be a sensible value which corresponds with the environment size and agent locations within your model/simulation.
 - ``LIGHT_POSITION`` The visualisation will contain a single light source which will be located at this position.
 - ``PAUSE_ON_START`` If defined the simulation is paused on launch, allowing the simulation to be visualised one iteration at a time. 
 
@@ -248,7 +248,7 @@ Creating a Custom Visualisation
 ===============================
 
 
-Customised visualisation can easily be integrated to a FLAME GPU project by extending the automatically generated visualisation file (the output of processing ``visualisation.xslt``). *Note: When doing this within Visual Studio it is important to turn off the template processing of the ``visualisation.xslt`` file in each of the launch configurations as processing them will overwrite any custom code!.*
+Customised visualisation can easily be integrated to a FLAME GPU project by extending the automatically generated visualisation file (the output of processing ``visualisation.xslt``). *Note: When doing this within Visual Studio it is important to turn off the template processing of the ``visualisation.xslt`` file in each of the launch configurations as processing them will overwrite any custom code!*
 Many of the FLAME GPU SDK examples use customised visualisations in this way.
 As with the default visualisations any custom visualisation must define the following function prototypes defined in the automatically generated simulation header.
 
@@ -261,7 +261,7 @@ As with the default visualisations any custom visualisation must define the foll
 
 
 
-The first of these can be used to initialise any OpenGL memory and CUDA OpengGL bindings as well as displaying the user interface.
+The first of these can be used to initialise any OpenGL memory and CUDA OpenGL bindings as well as displaying the user interface.
 The second of these functions must take control of the simulation by repeatedly calling the draw and singleIteration (which advances the simulation by a single iteration step) functions in a recursive loop.
 A more detailed description of the default rendering technique is provided within other FLAME GPU documentation (listed in :ref:`Purpose of This Document`).
 


### PR DESCRIPTION
Updates to spelling, wording and grammar within each of the documentation source files. I have checked that the docs still build locally after the changes.